### PR TITLE
Make limitstart parameter available for categories

### DIFF
--- a/joomplu.php
+++ b/joomplu.php
@@ -318,7 +318,7 @@ class plgContentJoomPlu extends JPlugin
             break;
         }
 
-        $rows   = $this->_interface->getPicsByCategory($match[1], $user->get('aid'), $ordering, $this->_interface->getConfig('limit'));
+        $rows   = $this->_interface->getPicsByCategory($match[1], $user->get('aid'), $ordering, $this->_interface->getConfig('limit'), $this->_interface->getConfig('limitstart'));
         $output = $this->_interface->displayThumbs($rows);
 
         $this->_interface->resetConfig();


### PR DESCRIPTION
With this change the parameter 'limitstart' is available for category insertions, e.g.:

{joomplucat:14 limit=3|limitstart=9}
