### PR TITLE
New option to load all images of the category ...

### DIFF
--- a/joomplu.php
+++ b/joomplu.php
@@ -319,7 +319,7 @@ class plgContentJoomPlu extends JPlugin
         }
 
         $loadAll       = $this->params->get('default_category_load_all', 0);
-        if($this->_interface->getConfig('category_load_all'))
+        if($this->_interface->getConfig('category_load_all') !== false)
         {
           $loadAll     = $this->_interface->getConfig('category_load_all');
         }

--- a/joomplu.php
+++ b/joomplu.php
@@ -318,8 +318,29 @@ class plgContentJoomPlu extends JPlugin
             break;
         }
 
-        $rows   = $this->_interface->getPicsByCategory($match[1], $user->get('aid'), $ordering, $this->_interface->getConfig('limit'), $this->_interface->getConfig('limitstart'));
-        $output = $this->_interface->displayThumbs($rows);
+        $loadAll       = $this->params->get('default_category_load_all', 0);
+        if($this->_interface->getConfig('category_load_all'))
+        {
+          $loadAll     = $this->_interface->getConfig('category_load_all');
+        }
+        $tmpLimit      = $loadAll ? 0 : $this->_interface->getConfig('limit');
+        $tmpLimitstart = $loadAll ? 0 : $this->_interface->getConfig('limitstart');
+        $rows          = $this->_interface->getPicsByCategory($match[1], $user->get('aid'), $ordering, $tmpLimit, $tmpLimitstart);
+        $output        = $this->_interface->displayThumbs($rows);
+
+        if($loadAll)
+        {
+          $output = preg_replace('/"jg_row /', '"jg_row hidden ', $output);
+
+          if(!$columnCount = $this->_interface->getConfig('columns'))
+          {
+            $columnCount = $this->_interface->getConfig('default_columns');
+          }
+
+          $rowsNotHidden = $columnCount > 0 ? intval($this->_interface->getConfig('limit') / $columnCount) : 1;
+
+          $output = preg_replace('/"jg_row hidden /', '"jg_row ', $output, $rowsNotHidden > 0 ? $rowsNotHidden : 1);
+        }
 
         $this->_interface->resetConfig();
 

--- a/joomplu.xml
+++ b/joomplu.xml
@@ -79,6 +79,10 @@
         </field>
         <field name="default_category_limit" type="text" default="4" label="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LIMIT" description="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LIMIT_DESCRIPTION" />
         <field name="default_category_columns" type="text" default="2" label="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_COLUMNS" description="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_COLUMNS_DESCRIPTION" />
+        <field name="default_category_load_all" type="radio" default="0" label="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LOAD_ALL" description="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LOAD_ALL_DESCRIPTION" class="btn-group">
+          <option value="0">JNO</option>
+          <option value="1">JYES</option>
+        </field>
         <field name="default_category_ordering" type="list" default="0" label="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_ORDERING" description="PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_ORDERING_DESCRIPTION">
           <option value="0">PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_ORDERING_ORDERING</option>
           <option value="1">PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_ORDERING_RANDOM</option>

--- a/language/de-DE/de-DE.plg_content_joomplu.ini
+++ b/language/de-DE/de-DE.plg_content_joomplu.ini
@@ -61,3 +61,11 @@ PLG_JOOMPLU_MESSAGE_SUBJECT="System Nachricht vom JoomGallery Content Plugin"
 PLG_JOOMPLU_MESSAGE_TEXT="Im Artikel "_QQ_"%3$s"_QQ_" mit der ID %2$d hat ein Besucher versucht sich ein Bild anzusehen, zu dem er keine Berechtigung hat es zu sehen oder das nicht (mehr) existiert [Bild-ID: %1$d]."
 PLG_JOOMPLU_JG_NOT_INSTALLED="Die JoomGallery ist nicht installiert."
 PLG_JOOMPLU_IMAGE_NOT_DISPLAYABLE="Sie haben leider nicht genügend Rechte, um dieses Bild zu sehen."
+;
+;------------------------------------------------------------------------------------
+; Gelöscht, neu oder geändert seit JoomPlu 3.2
+;------------------------------------------------------------------------------------
+;
+; Neu
+PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LOAD_ALL="Standard alle Thumbnails laden"
+PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LOAD_ALL_DESCRIPTION="Wenn diese Option aktiviert ist, werden alle Thumbnails dieser Kategorie geladen, angezeigt werden aber nur die durch Limit und Spaltenanzahl definierte Menge. Der Rest ist versteckt, dient aber bei der Verwendung eines Popups zur Detailbildanzeige dazu, dass alle Bilder der Kategorie angezeigt werden können."

--- a/language/en-GB/en-GB.plg_content_joomplu.ini
+++ b/language/en-GB/en-GB.plg_content_joomplu.ini
@@ -61,3 +61,11 @@ PLG_JOOMPLU_MESSAGE_SUBJECT="Invalid image :: System Message from the JoomGaller
 PLG_JOOMPLU_MESSAGE_TEXT="In the article "_QQ_"%3$s"_QQ_" with the id %2$d, a user tried to view an image which he is not allowed to see\n or which is not existent (anymore) [image id: %1$d]."
 PLG_JOOMPLU_JG_NOT_INSTALLED="JoomGallery is not installed."
 PLG_JOOMPLU_IMAGE_NOT_DISPLAYABLE="Sorry, you have not enough rights to view this image."
+;
+;------------------------------------------------------------------------------------
+; Deleted, new or changed constants since JoomPlu 3.2
+;------------------------------------------------------------------------------------
+;
+; New
+PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LOAD_ALL="Default load all thumbnails"
+PLG_JOOMPLU_FIELD_DEFAULT_CATEGORY_LOAD_ALL_DESCRIPTION="If this option is activated, all thumbnails of this category will be loaded, but only the amount defined by limit and number of columns will be displayed. The rest is hidden, but when using a pop-up to display the images they are used to display all images of the category."


### PR DESCRIPTION
... for displaying in a pop-up when using joomplucat

There is a new configuration option in the backend to make it possible to load all images of a category with joomplucat (partly hidden) in order to display them all in a pop-up.

You can override this default backend configuration option in an article when using ``category_load_all``:
``{joomplucat:6 limit=6|columns=3|group=group1|category_load_all=1}``
or
``{joomplucat:6 limit=6|columns=3|group=group1|category_load_all=0}``